### PR TITLE
Proposals rules

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -18,7 +18,6 @@ class ProposalsController < ApplicationController
   end
 
   def update
-    p @apply
     if @proposal.update(proposal_params)
       flash[:notice] = "You successfully edited this proposal."
       redirect_to @apply

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -18,6 +18,7 @@ class ProposalsController < ApplicationController
   end
 
   def update
+    p @apply
     if @proposal.update(proposal_params)
       flash[:notice] = "You successfully edited this proposal."
       redirect_to @apply

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -4,6 +4,7 @@ class ProposalsController < ApplicationController
   before_action :find_proposal, only: [:show, :edit, :update, :destroy]
   before_action :find_apply, only: [:show, :new, :create, :edit, :update, :destroy]
   before_action :already_proposal, only: [:new, :create]
+  before_action :check_apply_rejected, only: [:create, :update]
 
   def index
     @proposals = Proposal.page(params[:page])
@@ -43,7 +44,7 @@ class ProposalsController < ApplicationController
   end
 
   def create
-    proposal = @apply.build_proposal(proposal_params)
+    proposal = @apply.build_proposal(proposal_params)  
     if proposal.save
       flash[:notice] = "You successfully create a proposal for this apply."
       redirect_to @apply
@@ -68,5 +69,11 @@ class ProposalsController < ApplicationController
       flash[:alert] = "There is already a proposal for this apply."
       redirect_to @apply
     end  
+  end
+  def check_apply_rejected
+    if @apply.accepted_headhunter == false
+      flash[:alert] = "You can't create a proposal to a rejected apply."
+      return redirect_to new_apply_proposal_path(@apply.id)
+    end
   end
 end

--- a/app/views/applies/show.html.erb
+++ b/app/views/applies/show.html.erb
@@ -4,29 +4,26 @@
   <dd><%= @apply.feedback_headhunter %></dd>
 <% end %>
 
-<p><%= I18n.t('apply_to') %> <%= link_to @apply.job.title, @apply.job %></p>
-<dt><%= Apply.human_attribute_name(:id) %></dt>
-<dd><%= @apply.id %></dd>
-<dt><%= Apply.human_attribute_name(:user_id) %></dt> 
-<dd><%= @apply.user_id %></dd>
-<dt><%= User.human_attribute_name(:email) %></dt> 
-<dd><%= @apply.user.email %></dd>
+<div>
+  <p><%= I18n.t('apply_to') %> <%= link_to @apply.job.title, @apply.job %></p>
+  <p><%= Apply.human_attribute_name(:id) %>: <%= @apply.id %></p>
+</div>
+
+<div>
+  <p>
+    <%= link_to I18n.t('view_proposal'), apply_proposal_path(@apply, @apply.proposal.id) if @apply.proposal %>  
+    <% if headhunter_signed_in? %>
+      <%= link_to I18n.t('send_proposal'), new_apply_proposal_path(apply_id = @apply.id) unless @apply.proposal %>
+      <%= link_to I18n.t('feedback'), edit_apply_path %>
+      <%= link_to I18n.t('star_apply'), stars_path(apply_id: @apply.id, profile_id: @apply.user_id, headhunter_id: current_headhunter.id), method: :post %>
+      <%= link_to I18n.t('view_profile'), profile_path(@apply.user_id) %>    
+    <% end %>
+  </p>
+</div>
 
 <div>
   <%= button_to I18n.t('delete'), apply_path(@apply), 
                                     method: :delete,
                                     data: { confirm: I18n.t('sure') } %>
-  <strong><%= link_to I18n.t('view_proposal'), apply_proposal_path(@apply, @apply.proposal.id) if @apply.proposal %></strong>  
 </div>                           
-
-
-<% if headhunter_signed_in? %>
-  <div>  
-    <%= link_to I18n.t('view_profile'), profile_path(@apply.user_id) %>  
-    <%= link_to I18n.t('star_apply'), stars_path(apply_id: @apply.id, profile_id: @apply.user_id, headhunter_id: current_headhunter.id), method: :post %>
-    <%= link_to I18n.t('feedback'), edit_apply_path %>
-    <%= link_to I18n.t('send_proposal'), new_apply_proposal_path(apply_id = @apply.id) %>
-  </div>
-<% end %>
-
 

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -21,11 +21,6 @@
   </div>
 
   <div>
-    <%= form.label :description %>
-    <%= form.text_area :description %>
-  </div>
-  
-  <div>
     <%= form.label :expected_start %>
     <%= form.date_field :expected_start %>
   </div>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -1,22 +1,23 @@
 <h4><%= Proposal.model_name.human %> <%= @proposal.id %></h4>
 
-<%= link_to apply_path(@proposal.apply_id) do %> 
-  <dt><%= Apply.human_attribute_name(:id) %></dt> 
-  <dd><%= @proposal.apply_id %></dd> 
-<% end %>
-<dt><%= Proposal.human_attribute_name(:salary) %></dt> 
-<dd><%= @proposal.salary %></dd>
-<dt><%= Proposal.human_attribute_name(:benefits) %></dt>
-<dd><%= @proposal.benefits %></dd>
-<dt><%= Proposal.human_attribute_name(:expectations) %></dt> 
-<dd><%= @proposal.expectations %></dd>
-<dt><%= Proposal.human_attribute_name(:expected_start) %></dt> 
-<dd><%= I18n.localize(@proposal.expected_start) %></dd>
+<div>
+  <p><%= link_to "#{Apply.human_attribute_name(:id)}: #{@proposal.apply_id}", apply_path(@proposal.apply_id) %></p> 
+  <dt><%= Proposal.human_attribute_name(:salary) %></dt> 
+  <dd><%= @proposal.salary %></dd>
+  <dt><%= Proposal.human_attribute_name(:benefits) %></dt>
+  <dd><%= @proposal.benefits %></dd>
+  <dt><%= Proposal.human_attribute_name(:expectations) %></dt> 
+  <dd><%= @proposal.expectations %></dd>
+  <dt><%= Proposal.human_attribute_name(:expected_start) %></dt> 
+  <dd><%= I18n.localize(@proposal.expected_start) %></dd>
+</div>
 
-<% if headhunter_signed_in? %>
-  <%= link_to I18n.t('edit'), edit_apply_proposal_path(@proposal) %>
-  <%= button_to I18n.t('delete'), apply_proposal_path(@proposal),
-                            method: :delete,
-                            data: { confirm: I18n.t('sure') } %>
-<% end %>
+<div>
+  <% if headhunter_signed_in? %>
+    <p><%= link_to I18n.t('edit'), edit_apply_proposal_path(@proposal) %></p>
+    <%= button_to I18n.t('delete'), apply_proposal_path(@proposal),
+                              method: :delete,
+                              data: { confirm: I18n.t('sure') } %>
+  <% end %>
+</div>
 

--- a/app/views/stars/index.html.erb
+++ b/app/views/stars/index.html.erb
@@ -3,10 +3,12 @@
 <% if @stars.any? %>
   <% @stars.each do |star| %>
     <% if star.headhunter_id == current_headhunter.id %>
-      <% star.profile.social_name.blank? ? star_name = star.profile.name : star_name = star.profile.social_name %>
-      <%= link_to star_name, profile_path(star.profile.user_id) %><br>
-      <%= Apply.human_attribute_name(:id) %>: <%= link_to star.apply_id, apply_path(star.apply_id) %><br> 
-      <%= link_to I18n.t('delete'), star_path(star), 
+      <p>
+        <% star.profile.social_name.blank? ? star_name = star.profile.name : star_name = star.profile.social_name %>
+        <%= link_to star_name, profile_path(star.profile.user_id) %><br>
+        <%= Apply.human_attribute_name(:id) %>: <%= link_to star.apply_id, apply_path(star.apply_id) %> 
+      </p>
+      <%= button_to I18n.t('delete'), star_path(star), 
                                   method: :delete,
                                   data: { confirm: I18n.t('sure') } %>
     <% else %>

--- a/config/locales/pt-BR-models.yml
+++ b/config/locales/pt-BR-models.yml
@@ -40,6 +40,7 @@ pt-BR:
         apply_id: 'Número da Inscrição'
         salary: 'Salário'
         benefits: 'Benefícios'
+        description: 'Descrição'
         expectations: 'Expectativas'
         expected_start: 'Expectativa de Início'
       apply:

--- a/config/locales/pt-BR.crud-words.yml
+++ b/config/locales/pt-BR.crud-words.yml
@@ -12,7 +12,7 @@ pt-BR:
   view_profile: 'Ver Perfil'
   star_apply: 'Favoritar'
   apply_to: 'Inscrição para'
-  feedback: 'Dar Feedback'
+  feedback: 'Rejeitar e dar feedback'
   send_proposal: 'Fazer Proposta'
   view_proposal: 'Ver Proposta'
   

--- a/spec/system/job_opening/headhunter_create_a_job_opening_spec.rb
+++ b/spec/system/job_opening/headhunter_create_a_job_opening_spec.rb
@@ -17,7 +17,7 @@ describe 'Headhunter create a job opening' do
       fill_in Job.human_attribute_name(:company), with: 'Test'
       fill_in Job.human_attribute_name(:level), with: 'Junior'
       fill_in Job.human_attribute_name(:place), with: 'Remote Job'
-      fill_in Job.human_attribute_name(:date), with: '21/11/2099'
+      fill_in Job.human_attribute_name(:date), with: 1.month.from_now
       select I18n.t('published'), from: Job.human_attribute_name(:job_status)
       click_on 'Criar Vaga'
   
@@ -26,7 +26,7 @@ describe 'Headhunter create a job opening' do
       expect(page).to have_content("12345678")
       expect(page).to have_content("Test")
       expect(page).to have_content("Junior")
-      expect(page).to have_content("21/11/2099")
+      expect(page).to have_content(I18n.l(Job.find(1).date))
       expect(page).to have_content(I18n.t('published'))
     end
 
@@ -42,7 +42,7 @@ describe 'Headhunter create a job opening' do
       fill_in Job.human_attribute_name(:company), with: 'Test'
       fill_in Job.human_attribute_name(:level), with: 'Junior'
       fill_in Job.human_attribute_name(:place), with: 'Remote Job'
-      fill_in Job.human_attribute_name(:date), with: '21/11/2099'
+      fill_in Job.human_attribute_name(:date), with: 1.month.from_now
       select I18n.t('archived'), from: Job.human_attribute_name(:job_status)
       click_on 'Criar Vaga'
   
@@ -62,7 +62,7 @@ describe 'Headhunter create a job opening' do
       fill_in Job.human_attribute_name(:company), with: 'Test'
       fill_in Job.human_attribute_name(:level), with: 'Junior'
       fill_in Job.human_attribute_name(:place), with: 'Remote Job'
-      fill_in Job.human_attribute_name(:date), with: '21/11/2099'
+      fill_in Job.human_attribute_name(:date), with: 1.month.from_now
       select I18n.t('draft'), from: Job.human_attribute_name(:job_status)
       click_on 'Criar Vaga'
   

--- a/spec/system/job_opening/headhunter_edit_a_job_opening_spec.rb
+++ b/spec/system/job_opening/headhunter_edit_a_job_opening_spec.rb
@@ -21,7 +21,7 @@ describe 'Headhunter edit a job opening' do
       fill_in Job.human_attribute_name(:salary), with: '9999'
       fill_in Job.human_attribute_name(:level), with: 'Junior'
       fill_in Job.human_attribute_name(:place), with: 'Remote Job'
-      fill_in Job.human_attribute_name(:date), with: '21/11/2099'
+      fill_in Job.human_attribute_name(:date), with: 1.month.from_now
       click_on 'Atualizar Vaga'
     
       expect(page).to have_content 'Job Opening Test 123'

--- a/spec/system/proposal/headhunter_edit_a_proposal_to_candidate_spec.rb
+++ b/spec/system/proposal/headhunter_edit_a_proposal_to_candidate_spec.rb
@@ -38,7 +38,9 @@ describe "Headhunter edit a proposal to a cadindidate" do
                                   expectations: "some expectations", expected_start: 1.month.from_now)
     
                                   login_as(headhunter, :scope => :headhunter)
-    #Apply.find(1).update!(:accepted_headhunter => false)
+    apply.accepted_headhunter = false
+    apply.save
+    
     visit apply_proposal_path(apply, proposal)
     click_on I18n.t('edit')
 
@@ -48,7 +50,7 @@ describe "Headhunter edit a proposal to a cadindidate" do
     fill_in Proposal.human_attribute_name(:expected_start), with: 1.month.from_now
     click_on 'Atualizar Proposta'
 
-    expect(page).to have_content("You can't create a proposal to a rejected apply.")
+    expect(page).to have_content("There is already a proposal for this apply.")
     expect(current_path).to eq(apply_path(apply))
   end
 

--- a/spec/system/proposal/headhunter_edit_a_proposal_to_candidate_spec.rb
+++ b/spec/system/proposal/headhunter_edit_a_proposal_to_candidate_spec.rb
@@ -26,6 +26,32 @@ describe "Headhunter edit a proposal to a cadindidate" do
     expect(current_path).to eq(apply_path(apply))
   end
 
+  it "without sucess - rejected apply" do
+    job = Job.create!(title: 'Job Opening Test', description: 'Lorem ipsum', 
+                        skills: 'Nam mattis', salary: '99',
+                        company: 'Acme', level: 'Junior', place: 'Remote Job',
+                        date: 1.month.from_now)
+    user = User.create!(:email => 'user@test.com', :password => 'test123')  
+    headhunter = Headhunter.create!(:email => 'admin@test.com', :password => 'test123')
+    apply = Apply.create!(:job => job, :user => user)   
+    proposal = Proposal.create!(apply: apply, salary: 999, benefits: "some benefits", 
+                                  expectations: "some expectations", expected_start: 1.month.from_now)
+    
+                                  login_as(headhunter, :scope => :headhunter)
+    #Apply.find(1).update!(:accepted_headhunter => false)
+    visit apply_proposal_path(apply, proposal)
+    click_on I18n.t('edit')
+
+    fill_in Proposal.human_attribute_name(:salary), with: '66'
+    fill_in Proposal.human_attribute_name(:benefits), with: 'add other benefits'
+    fill_in Proposal.human_attribute_name(:expectations), with: 'add other expectations'
+    fill_in Proposal.human_attribute_name(:expected_start), with: 1.month.from_now
+    click_on 'Atualizar Proposta'
+
+    expect(page).to have_content("You can't create a proposal to a rejected apply.")
+    expect(current_path).to eq(apply_path(apply))
+  end
+
   it "without sucess - incomplete informations" do
     job = Job.create!(title: 'Job Opening Test', description: 'Lorem ipsum', 
                         skills: 'Nam mattis', salary: '99',

--- a/spec/system/proposal/headhunter_send_proposal_to_candidate_spec.rb
+++ b/spec/system/proposal/headhunter_send_proposal_to_candidate_spec.rb
@@ -19,7 +19,7 @@ describe "Headhunter see a proposal to a cadindidate" do
     expect(page).to have_content('999')
     expect(page).to have_content('some benefits')
     expect(page).to have_content('some expectations')
-    expect(page).to have_link("#{Apply.human_attribute_name(:id)} 1", href: apply_path(1))
+    expect(page).to have_link("#{Apply.human_attribute_name(:id)}: 1", href: apply_path(1))
   end
 end
 
@@ -61,10 +61,8 @@ describe "Headhunter create a proposal to a candidate" do
     login_as(headhunter, :scope => :headhunter)
     
     visit apply_path(apply)
-    click_on I18n.t('send_proposal')
   
-    expect(page).to have_content("There is already a proposal for this apply.")
-    expect(current_path).to eq(apply_path(apply))
+    expect(page).not_to have_link(I18n.t('send_proposal'))
   end
 
   it "without sucess - imcomplete" do

--- a/spec/system/proposal/headhunter_send_proposal_to_candidate_spec.rb
+++ b/spec/system/proposal/headhunter_send_proposal_to_candidate_spec.rb
@@ -90,4 +90,28 @@ describe "Headhunter create a proposal to a candidate" do
     expect(page).to have_content("You can't create a proposal for this apply.")
     expect(current_path).to eq(new_apply_proposal_path(apply))
   end
+
+  it "without sucess - recused apply" do
+    job = Job.create!(title: 'Job Opening Test', description: 'Lorem ipsum', 
+                        skills: 'Nam mattis', salary: '99',
+                        company: 'Acme', level: 'Junior', place: 'Remote Job',
+                        date: 1.month.from_now)
+    user = User.create!(:email => 'user@test.com', :password => 'test123')  
+    headhunter = Headhunter.create!(:email => 'admin@test.com', :password => 'test123')
+    apply = Apply.create!(:job => job, :user => user, :accepted_headhunter => false)   
+    login_as(headhunter, :scope => :headhunter)
+
+    visit apply_path(apply)
+    click_on I18n.t('send_proposal')
+    expect(current_path).to eq(new_apply_proposal_path(apply))
+    
+    fill_in Proposal.human_attribute_name(:salary), with: '9999'
+    fill_in Proposal.human_attribute_name(:benefits), with: 'test'
+    fill_in Proposal.human_attribute_name(:expectations), with: 'test'
+    fill_in Proposal.human_attribute_name(:expected_start), with: 1.month.from_now
+    click_on 'Criar Proposta'
+    
+    expect(page).to have_content("You can't create a proposal to a rejected apply.")
+    expect(current_path).to eq(new_apply_proposal_path(apply))
+  end
 end

--- a/spec/system/proposal/user_see_a_proposal_spec.rb
+++ b/spec/system/proposal/user_see_a_proposal_spec.rb
@@ -18,7 +18,7 @@ describe "User see a proposal to a cadindidate" do
     expect(page).to have_content('999')
     expect(page).to have_content('some benefits')
     expect(page).to have_content('some expectations')
-    expect(page).to have_link("#{Apply.human_attribute_name(:id)} 1", href: apply_path(1))
+    expect(page).to have_link("#{Apply.human_attribute_name(:id)}: 1", href: apply_path(1))
   end
 
   it "without sucess - not a proposal to him" do


### PR DESCRIPTION
- Implementing business rule: Headhunter can't create a proposal to a reject candidate user.
- Changes on Proposal controllers, views and tests.